### PR TITLE
Refactoring of updateEffects in skill.js

### DIFF
--- a/js/nautsbuilder/data/skill.js
+++ b/js/nautsbuilder/data/skill.js
@@ -93,20 +93,15 @@ leiminauts.Skill = Backbone.Model.extend({
 	},
 
 	getActiveUpgrades: function() {
-		var activeUpgrades = this.upgrades.filter(function(upgrade) {
+		return this.upgrades.filter(function(upgrade) {
 			return upgrade.get('active') === true;
 		});
-		return activeUpgrades;
 	},
 
 	getActiveSteps: function() {
-		var activeSteps = [];
-		this.upgrades.each(function(upgrade) {
-			if (upgrade.get('active') === true) {
-				activeSteps.push(upgrade.get('current_step'));
-			}
+		return this.getActiveUpgrades().map(function(upgrade) {
+			return upgrade.get('current_step');
 		});
-		return activeSteps;
 	},
 
 	updateEffects: function(e) {


### PR DESCRIPTION
I did a whole bunch of refactoring to the `updateEffects` function of skill.js. I introduced a lot of additional functions to make the main method easier to read.
The important changes:
- The merging of the `baseEffects` and `activeSteps` is now done in an extra function `mergeEffectsAndSteps`. I changed the main "algorithm" behind it. Like before, all attribute values are combined into a list for each attribute.
  To ensure that the lists have the correct ordering, they get sorted afterwards, depending if an element is a divisor or not. This sorting can easily be extended in such a way that adding and multiplying (+ and +%) has the correct order as well - if necessary.
- The merging of the baseEffect and the upgrades into one attribute is now done in `applyUpgrades` (for all of them), `applyUpgrade` (for one specific attribute) and `applyOperation` (executing the number operation, e.g. x += y, x *= 1 + y, etc.).

This refactoring is the first step to enable multi staged upgrades natively (see branch [damage-stages](https://github.com/r0estir0bbe/nautsbuilder/tree/damage-stages)).
