### PR TITLE
Refactoring of upgrade & effect initialization in skill.js

### DIFF
--- a/js/nautsbuilder/data/skill.js
+++ b/js/nautsbuilder/data/skill.js
@@ -96,6 +96,12 @@ leiminauts.Skill = Backbone.Model.extend({
 				skillUpgrades[index] = _(newUpgrade).clone();
 			});
 		}
+		
+		// Link the upgrade to the skill to enable upgrade shortcut
+		_(skillUpgrades).each(function(upgrade) {
+			upgrade.skill = this;
+		}, this);
+		
 		this.get('upgrades').reset(skillUpgrades);
 		this.resetUpgradesState();
 	},


### PR DESCRIPTION
I refactored the methods prepareBaseEffects (now called initBaseEffects) and initUpgrades. Most importantly, the part about character specific pills and jump skills got changed to improve readability.
This change also enables future feature changes to pills in such a way that people can create new pills without having to change parts of the code. See issue #5 and my branch [issue5](https://github.com/r0estir0bbe/nautsbuilder/tree/issue5).
