### PR TITLE
Native support of effect stages in skills and upgrades

### DIFF
--- a/js/nautsbuilder/data/skill.js
+++ b/js/nautsbuilder/data/skill.js
@@ -220,8 +220,8 @@ leiminauts.Skill = Backbone.Model.extend({
 			_(upgrades).each(function(upgrade) {
 				var upgradeStages = String(upgrade).split(' > ');
 				var regexResults = [];
-				_(upgradeStages).each(function(u, i) {
-					regexResults[i] = upgradeRegex.exec(u);
+				_(upgradeStages).each(function(u) {
+					regexResults.push(upgradeRegex.exec(u));
 				});
 
 				if (effectStages.length == 1 && upgradeStages.length > 1) {
@@ -470,7 +470,7 @@ leiminauts.Skill = Backbone.Model.extend({
 			}
 		}
 		var dps = effects.findWhere({key: "DPS"});
-		if (attackSpeedEffect && damageEffect) {
+		if (attackSpeedEffect && damage) {
 			dpsVal = leiminauts.utils.dps(damage, attackSpeedEffect.value);
 			if (dps) dps.value = dpsVal;
 			else {


### PR DESCRIPTION
I implemented the native support of effect stages in both skills and upgrades. Effect stages are e.g. `Damage: 11 > 14 > 25`, `Slowing Power: 7.5% > 15% > 22.5% > 30%` or `Amplify damage: 20% > 25% > 30% > 35%`.
By native support, I mean that skills and/or effects can have multiple stages and they get applied to each other correctly. The four possible combinations work natively for any effect:

| base effect | upgrade | result |
| :-: | :-: | :-: |
| `Damage: 10` | `Damage: +1` | `Damage: 11` |
| `Damage: 10` | `Damage: +1 > +2 > +3 > +4` | `Damage: 11 > 12 > 13 > 14` |
| `Damage: 11 > 12 > 13 > 14` | `Damage: +1` | `Damage: 12 > 13 > 14 > 15` |
| `Damage: 11 > 12 > 13 > 14` | `Damage: +1 > +2 > +3 > +4` | `Damage: 12 > 14 > 16 > 18` |

Additionally, if the `damage` effect has multiple stages, the Nautsbuilder automatically calculates `avg. damage` if not already set.
Because of these changes, specific code for both Skølldir's Bash and Ayla's Evil Eye has been removed. Obviously, the spreadsheet has to be updated accordinly.
